### PR TITLE
Fix object error logging

### DIFF
--- a/src/logging.service.ts
+++ b/src/logging.service.ts
@@ -46,7 +46,7 @@ export class LoggingService extends ConsoleLogger implements LoggerService {
   error(message: any) {
     if (LoggingService.params.GCP_ERROR_REPORTING) {
       // Wrapping the message in a Error stack makes the Error Reporter recognize it.
-      message = Error(message).stack;
+      message = typeof message === 'object' ? Error(JSON.stringify(message)).stack : Error(message).stack;
     }
     console.log(JSON.stringify({severity: Severity.ERROR, message: message}));
   }


### PR DESCRIPTION
The `error` method accepts `any` value but if the object is provided it hasn't been logged properly:
```
Error({ errorMessage: 'some-error-message' }).stack
```
is logged as
```
'Error: [object Object]\n    at <anonymous>:1:1'
```