### PR TITLE
Simplify LoggingModule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,23 +1,588 @@
 module.exports = {
-  'env': {
-    'browser': true,
-    'es2021': true,
+  "env": {
+    "node": true,
+    "jest": true
   },
-  'extends': [
-    'google',
+  "parserOptions": {
+    "ecmaVersion": 12,
+    "sourceType": "module",
+    "allowImportExportEverywhere": false,
+    "codeFrame": false
+  },
+  "plugins": [
+    "prettier",
+    "@typescript-eslint"
   ],
-  'parser': '@typescript-eslint/parser',
-  'parserOptions': {
-    'ecmaVersion': 'latest',
-    'sourceType': 'module',
+  "rules": {
+    "@typescript-eslint/no-use-before-define": [
+      "off"
+    ],
+    "quotes": [
+      2,
+      "single",
+      "avoid-escape"
+    ],
+    "import/prefer-default-export": [
+      "off"
+    ],
+    "import/extensions": [
+      "off"
+    ],
+    "spaced-comment": [
+      "off",
+      "always"
+    ],
+    "no-extra-boolean-cast": [
+      "off"
+    ],
+    "no-nested-ternary": [
+      "off"
+    ],
+    "no-use-before-define": [
+      "off"
+    ],
+    "no-shadow": [
+      "off"
+    ],
+    "@typescript-eslint/no-shadow": [
+      "error"
+    ],
+    "@typescript-eslint/explicit-function-return-type": [
+      "off"
+    ],
+    "@typescript-eslint/interface-name-prefix": [
+      "off"
+    ],
+    "@typescript-eslint/ban-ts-ignore": [
+      "off"
+    ],
+    "@typescript-eslint/ban-ts-comment": [
+      "off"
+    ],
+    "@typescript-eslint/ban-types": [
+      "off"
+    ],
+    "@typescript-eslint/explicit-module-boundary-types": [
+      "off"
+    ],
+    "@typescript-eslint/no-unused-vars": [
+      "error"
+    ],
+    "no-console": [
+      "off"
+    ],
+    "no-implicit-coercion": [
+      "error"
+    ],
+    "no-process-env": [
+      "off"
+    ],
+    "no-restricted-syntax": [
+      "error",
+      "ForInStatement",
+      "LabeledStatement",
+      "WithStatement"
+    ],
+    "no-underscore-dangle": [
+      "off"
+    ],
+    "no-unused-expressions": [
+      "error"
+    ],
+    "prefer-promise-reject-errors": [
+      "error"
+    ],
+    "no-unused-vars": [
+      "off",
+      {
+        "args": "none"
+      }
+    ],
+    "valid-jsdoc": [
+      "off",
+      {
+        "requireParamDescription": false,
+        "requireReturnDescription": false,
+        "requireReturn": false,
+        "prefer": {
+          "returns": "return"
+        },
+        "requireReturnType": true,
+        "requireParamType": true
+      }
+    ],
+    "new-cap": [
+      "off"
+    ],
+    "require-jsdoc": [
+      "off",
+      {
+        "require": {
+          "FunctionDeclaration": true,
+          "MethodDefinition": true,
+          "ClassDeclaration": true,
+          "ArrowFunctionExpression": false,
+          "FunctionExpression": false
+        }
+      }
+    ],
+    "prettier/prettier": [
+      "error"
+    ],
+    "arrow-body-style": [
+      "off"
+    ],
+    "prefer-arrow-callback": [
+      "off"
+    ],
+    "curly": [
+      0,
+      "multi-line"
+    ],
+    "lines-around-comment": [
+      0
+    ],
+    "max-len": [
+      0,
+      {
+        "code": 80,
+        "tabWidth": 2,
+        "ignoreUrls": true,
+        "ignorePattern": "goog.(module|require)"
+      }
+    ],
+    "no-confusing-arrow": [
+      0
+    ],
+    "no-mixed-operators": [
+      0
+    ],
+    "no-tabs": [
+      0
+    ],
+    "no-unexpected-multiline": [
+      0
+    ],
+    "array-bracket-newline": [
+      "off"
+    ],
+    "array-bracket-spacing": [
+      "off",
+      "never"
+    ],
+    "array-element-newline": [
+      "off"
+    ],
+    "arrow-parens": [
+      "off",
+      "always"
+    ],
+    "arrow-spacing": [
+      "off"
+    ],
+    "block-spacing": [
+      "off",
+      "never"
+    ],
+    "brace-style": [
+      "off"
+    ],
+    "comma-dangle": [
+      "off",
+      "always-multiline"
+    ],
+    "comma-spacing": [
+      "off"
+    ],
+    "comma-style": [
+      "off"
+    ],
+    "computed-property-spacing": [
+      "off"
+    ],
+    "dot-location": [
+      "off"
+    ],
+    "eol-last": [
+      "off"
+    ],
+    "func-call-spacing": [
+      "off"
+    ],
+    "function-call-argument-newline": [
+      "off"
+    ],
+    "function-paren-newline": [
+      "off"
+    ],
+    "generator-star": [
+      "off"
+    ],
+    "generator-star-spacing": [
+      "off",
+      "after"
+    ],
+    "implicit-arrow-linebreak": [
+      "off"
+    ],
+    "indent": [
+      "off",
+      2,
+      {
+        "CallExpression": {
+          "arguments": 2
+        },
+        "FunctionDeclaration": {
+          "body": 1,
+          "parameters": 2
+        },
+        "FunctionExpression": {
+          "body": 1,
+          "parameters": 2
+        },
+        "MemberExpression": 2,
+        "ObjectExpression": 1,
+        "SwitchCase": 1,
+        "ignoredNodes": [
+          "ConditionalExpression"
+        ],
+        "flatTernaryExpressions": false,
+        "offsetTernaryExpressions": false,
+        "ignoreComments": false
+      }
+    ],
+    "jsx-quotes": [
+      "off"
+    ],
+    "key-spacing": [
+      "off"
+    ],
+    "keyword-spacing": [
+      "off"
+    ],
+    "linebreak-style": [
+      "off"
+    ],
+    "multiline-ternary": [
+      "off"
+    ],
+    "newline-per-chained-call": [
+      "off"
+    ],
+    "new-parens": [
+      "off"
+    ],
+    "no-arrow-condition": [
+      "off"
+    ],
+    "no-comma-dangle": [
+      "off"
+    ],
+    "no-extra-parens": [
+      "off"
+    ],
+    "no-extra-semi": [
+      "off"
+    ],
+    "no-floating-decimal": [
+      "off"
+    ],
+    "no-mixed-spaces-and-tabs": [
+      "off"
+    ],
+    "no-multi-spaces": [
+      "off"
+    ],
+    "no-multiple-empty-lines": [
+      "off",
+      {
+        "max": 2
+      }
+    ],
+    "no-reserved-keys": [
+      "off"
+    ],
+    "no-space-before-semi": [
+      "off"
+    ],
+    "no-trailing-spaces": [
+      "off"
+    ],
+    "no-whitespace-before-property": [
+      "off"
+    ],
+    "no-wrap-func": [
+      "off"
+    ],
+    "nonblock-statement-body-position": [
+      "off"
+    ],
+    "object-curly-newline": [
+      "off"
+    ],
+    "object-curly-spacing": [
+      "off"
+    ],
+    "object-property-newline": [
+      "off"
+    ],
+    "one-var-declaration-per-line": [
+      "off"
+    ],
+    "operator-linebreak": [
+      "off",
+      "after"
+    ],
+    "padded-blocks": [
+      "off",
+      "never"
+    ],
+    "quote-props": [
+      "off",
+      "consistent"
+    ],
+    "rest-spread-spacing": [
+      "off"
+    ],
+    "semi": [
+      "off"
+    ],
+    "semi-spacing": [
+      "off"
+    ],
+    "semi-style": [
+      "off"
+    ],
+    "space-after-function-name": [
+      "off"
+    ],
+    "space-after-keywords": [
+      "off"
+    ],
+    "space-before-blocks": [
+      "off"
+    ],
+    "space-before-function-paren": [
+      "off",
+      {
+        "asyncArrow": "always",
+        "anonymous": "never",
+        "named": "never"
+      }
+    ],
+    "space-before-function-parentheses": [
+      "off"
+    ],
+    "space-before-keywords": [
+      "off"
+    ],
+    "space-in-brackets": [
+      "off"
+    ],
+    "space-in-parens": [
+      "off"
+    ],
+    "space-infix-ops": [
+      "off"
+    ],
+    "space-return-throw-case": [
+      "off"
+    ],
+    "space-unary-ops": [
+      "off"
+    ],
+    "space-unary-word-ops": [
+      "off"
+    ],
+    "switch-colon-spacing": [
+      "off"
+    ],
+    "template-curly-spacing": [
+      "off"
+    ],
+    "template-tag-spacing": [
+      "off"
+    ],
+    "unicode-bom": [
+      "off"
+    ],
+    "wrap-iife": [
+      "off"
+    ],
+    "wrap-regex": [
+      "off"
+    ],
+    "yield-star-spacing": [
+      "off",
+      "after"
+    ],
+    "indent-legacy": [
+      "off"
+    ],
+    "no-spaced-func": [
+      "off"
+    ],
+    "@typescript-eslint/adjacent-overload-signatures": [
+      "error"
+    ],
+    "no-array-constructor": [
+      "off"
+    ],
+    "@typescript-eslint/no-array-constructor": [
+      "error"
+    ],
+    "no-empty-function": [
+      "off"
+    ],
+    "@typescript-eslint/no-empty-function": [
+      "error"
+    ],
+    "@typescript-eslint/no-empty-interface": [
+      "error"
+    ],
+    "@typescript-eslint/no-explicit-any": [
+      "warn"
+    ],
+    "@typescript-eslint/no-extra-non-null-assertion": [
+      "error"
+    ],
+    "@typescript-eslint/no-extra-semi": [
+      "error"
+    ],
+    "@typescript-eslint/no-inferrable-types": [
+      "error"
+    ],
+    "no-loss-of-precision": [
+      "off"
+    ],
+    "@typescript-eslint/no-loss-of-precision": [
+      "error"
+    ],
+    "@typescript-eslint/no-misused-new": [
+      "error"
+    ],
+    "@typescript-eslint/no-namespace": [
+      "error"
+    ],
+    "@typescript-eslint/no-non-null-asserted-optional-chain": [
+      "error"
+    ],
+    "@typescript-eslint/no-non-null-assertion": [
+      "warn"
+    ],
+    "@typescript-eslint/no-this-alias": [
+      "error"
+    ],
+    "@typescript-eslint/no-unnecessary-type-constraint": [
+      "error"
+    ],
+    "@typescript-eslint/no-var-requires": [
+      "error"
+    ],
+    "@typescript-eslint/prefer-as-const": [
+      "error"
+    ],
+    "@typescript-eslint/prefer-namespace-keyword": [
+      "error"
+    ],
+    "@typescript-eslint/triple-slash-reference": [
+      "error"
+    ],
+    "no-cond-assign": [
+      0
+    ],
+    "no-irregular-whitespace": [
+      2
+    ],
+    "guard-for-in": [
+      2
+    ],
+    "no-caller": [
+      2
+    ],
+    "no-extend-native": [
+      2
+    ],
+    "no-extra-bind": [
+      2
+    ],
+    "no-invalid-this": [
+      2
+    ],
+    "no-multi-str": [
+      2
+    ],
+    "no-new-wrappers": [
+      2
+    ],
+    "no-throw-literal": [
+      2
+    ],
+    "no-with": [
+      2
+    ],
+    "camelcase": [
+      2,
+      {
+        "properties": "never",
+        "ignoreDestructuring": false,
+        "ignoreImports": false,
+        "ignoreGlobals": false
+      }
+    ],
+    "no-new-object": [
+      2
+    ],
+    "one-var": [
+      2,
+      {
+        "var": "never",
+        "let": "never",
+        "const": "never"
+      }
+    ],
+    "constructor-super": [
+      2
+    ],
+    "no-new-symbol": [
+      2
+    ],
+    "no-this-before-super": [
+      2
+    ],
+    "no-var": [
+      2
+    ],
+    "prefer-const": [
+      2,
+      {
+        "destructuring": "all",
+        "ignoreReadBeforeAssign": false
+      }
+    ],
+    "prefer-rest-params": [
+      2
+    ],
+    "prefer-spread": [
+      2
+    ]
   },
-  'plugins': [
-    '@typescript-eslint',
-  ],
-  'rules': {
-    'new-cap': 1,
-    'require-jsdoc': 0,
-    'no-unused-vars': 0,
-    '@typescript-eslint/no-unused-vars': 2,
+  "settings": {
+    "import/resolver": {
+      "node": {
+        "paths": [
+          "src"
+        ],
+        "extensions": [
+          ".js",
+          ".jsx",
+          ".ts",
+          ".tsx"
+        ]
+      }
+    }
   },
+  "ignorePatterns": [
+    ".eslintrc.js"
+  ]
 };

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+  printWidth: 120,
+  trailingComma: "all",
+  tabWidth: 2,
+  semi: true,
+  singleQuote: true,
+  bracketSpacing: true
+}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 ```typescript
 // app.module.ts
 import { Module } from '@nestjs/common';
-import { LoggingModule } from '@lightness/nestjs-gcp-logger'; // <-- Import the module
+import { LoggingModule } from '@pzwik/nestjs-gcp-logger'; // <-- Import the module
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 
@@ -35,7 +35,7 @@ export class AppModule { }
 ```typescript
 // main.ts
 import { NestFactory } from '@nestjs/core';
-import { LoggingService } from '@lightness/nestjs-gcp-logger'; // <-- Import here
+import { LoggingService } from '@pzwik/nestjs-gcp-logger'; // <-- Import here
 import { AppModule } from './app.module';
 
 async function bootstrap() {
@@ -99,3 +99,63 @@ export class AppService {
   
   await app.init();
 ```
+
+### Migrate 1.X -> 2.X
+
+1. Update module creation
+  * from 
+  ```ts
+  LoggingModule.register()
+  ```
+  * to 
+  ```ts
+  LoggingModule.forRoot()
+  ```
+2. Update name of param
+  * from 
+  ```ts
+  GCP_ERROR_REPORTING
+  ```
+  * to 
+  ```ts
+  gcpErrorReporting
+  ```
+3. Update how logger passed to app 
+  * from 
+  ```ts
+  const app = await NestFactory.create(AppModule, { logger: new LoggingService() });
+  ```
+  * to 
+  ```ts
+  const app = await NestFactory.create(AppModule, { bufferLogs: true });
+  app.useLogger(app.get(LoggingService))
+  ```
+4. Update logger usage in services
+  * from
+  ```ts
+  import { Injectable, Logger } from '@nestjs/common';
+
+  @Injectable()
+  export class AppService {
+    getHello(): string {
+      Logger.error('Some Error happened!');
+      return 'Hello World!';
+    }
+  }
+  ```
+  * to
+  ```ts
+  import { Injectable, Logger } from '@nestjs/common';
+
+  @Injectable()
+  export class AppService {
+    private readonly logger = new Logger('AppService');
+
+    getHello(): string {
+      this.logger.error('Some Error happened!');
+      return 'Hello World!';
+    }
+  }
+  ```
+
+

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@
 ```typescript
 // app.module.ts
 import { Module } from '@nestjs/common';
+import { LoggingModule } from '@lightness/nestjs-gcp-logger'; // <-- Import the module
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
-import { LoggingModule } from '@pzwik/nestjs-gcp-logger'; // <-- Import the module
 
 @Module({
   imports: [
@@ -35,7 +35,7 @@ export class AppModule { }
 ```typescript
 // main.ts
 import { NestFactory } from '@nestjs/core';
-import { LoggingService } from '@pzwik/nestjs-gcp-logger'; // <-- Import here
+import { LoggingService } from '@lightness/nestjs-gcp-logger'; // <-- Import here
 import { AppModule } from './app.module';
 
 async function bootstrap() {
@@ -61,3 +61,41 @@ export class AppService {
   }
 }
 ````
+
+### How to mock in tests
+
+```typescript
+  // logger.mock.ts
+  export class LoggerMock {
+  log() {
+    return;
+  }
+  error() {
+    return;
+  }
+  warn() {
+    return;
+  }
+  debug() {
+    return;
+  }
+  verbose() {
+    return;
+  }
+}
+```
+
+```typescript
+  // test.spec.ts
+  const moduleFixture = await Test.createTestingModule({...})
+    .overrideProvider(LoggingService)
+    .useClass(LoggerMock)
+    .compile();
+
+  const app = moduleFixture.createNestApplication();
+
+  // Do not forget to set the logger, otherwise nestjs default logger
+  app.useLogger(app.get(LoggingService));
+  
+  await app.init();
+```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 | Property              | Default | Description |
 | ---                   | ---     | --- |
-| `GCP_ERROR_REPORTING` | `false` | If set to `true` all error messages are recognized by GCP Error Reporting by wrapping the provided message in a stack trace |
+| `gcpErrorReporting`   | `false` | If set to `true` all error messages are recognized by GCP Error Reporting by wrapping the provided message in a stack trace |
 
 
 
@@ -21,8 +21,8 @@ import { LoggingModule } from '@pzwik/nestjs-gcp-logger'; // <-- Import the modu
 
 @Module({
   imports: [
-    LoggingModule.register({ // <-- Initialize the module
-      GCP_ERROR_REPORTING: false // default is 'false'
+    LoggingModule.forRoot({ // <-- Initialize the module
+      gcpErrorReporting: false // default is 'false'
     })
   ],
   controllers: [AppController],
@@ -39,9 +39,9 @@ import { LoggingService } from '@pzwik/nestjs-gcp-logger'; // <-- Import here
 import { AppModule } from './app.module';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule, { 
-    logger: new LoggingService() // <-- Instantiate here
-  });
+  const app = await NestFactory.create(AppModule, { bufferLogs: true });
+  app.useLogger(app.get(LoggingService));
+
   await app.listen(3000);
 }
 bootstrap();
@@ -52,8 +52,10 @@ import { Injectable, Logger } from '@nestjs/common'; // <-- Import Logger from N
 
 @Injectable()
 export class AppService {
+  private readonly logger = new Logger('AppService');
+
   getHello(): string {
-    Logger.error('Some Error happened!'); // <-- Calls the logger
+    this.logger.error('Some Error happened!'); // <-- Calls the logger
     // {"severity":"ERROR","message":"Some Error happened!"}
     return 'Hello World!';
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lightness/nestjs-gcp-logger",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lightness/nestjs-gcp-logger",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "ISC",
       "dependencies": {
         "@nestjs/common": "^9.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@lightness/nestjs-gcp-logger",
-  "version": "2.0.2",
+  "name": "@pzwik/nestjs-gcp-logger",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@lightness/nestjs-gcp-logger",
-      "version": "2.0.2",
+      "name": "@pzwik/nestjs-gcp-logger",
+      "version": "2.0.0",
       "license": "ISC",
       "dependencies": {
         "@nestjs/common": "^9.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pzwik/nestjs-gcp-logger",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pzwik/nestjs-gcp-logger",
-      "version": "1.1.2",
+      "version": "2.0.0",
       "license": "ISC",
       "dependencies": {
         "@nestjs/common": "^9.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lightness/nestjs-gcp-logger",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lightness/nestjs-gcp-logger",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "ISC",
       "dependencies": {
         "@nestjs/common": "^9.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@pzwik/nestjs-gcp-logger",
+  "name": "@lightness/nestjs-gcp-logger",
   "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@pzwik/nestjs-gcp-logger",
+      "name": "@lightness/nestjs-gcp-logger",
       "version": "2.0.0",
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightness/nestjs-gcp-logger",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightness/nestjs-gcp-logger",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
@@ -33,7 +33,9 @@
     "typescript": "^4.3.5"
   },
   "author": "Pascal Zwikirsch",
-  "contributors": ["Uladzimir Aleshka"],
+  "contributors": [
+    "Uladzimir Aleshka"
+  ],
   "homepage": "https://github.com/mr-pascal/nestjs-gcp-logging",
   "bugs": {
     "url": "https://github.com/mr-pascal/nestjs-gcp-logging"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@lightness/nestjs-gcp-logger",
-  "version": "2.0.2",
+  "name": "@pzwik/nestjs-gcp-logger",
+  "version": "2.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
@@ -36,9 +36,9 @@
   "contributors": [
     "Uladzimir Aleshka"
   ],
-  "homepage": "https://github.com/lightness/nestjs-gcp-logging",
+  "homepage": "https://github.com/mr-pascal/nestjs-gcp-logging",
   "bugs": {
-    "url": "https://github.com/lightness/nestjs-gcp-logging"
+    "url": "https://github.com/mr-pascal/nestjs-gcp-logging"
   },
   "license": "ISC",
   "jest": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightness/nestjs-gcp-logger",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
   "contributors": [
     "Uladzimir Aleshka"
   ],
-  "homepage": "https://github.com/mr-pascal/nestjs-gcp-logging",
+  "homepage": "https://github.com/lightness/nestjs-gcp-logging",
   "bugs": {
-    "url": "https://github.com/mr-pascal/nestjs-gcp-logging"
+    "url": "https://github.com/lightness/nestjs-gcp-logging"
   },
   "license": "ISC",
   "jest": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@pzwik/nestjs-gcp-logger",
+  "name": "@lightness/nestjs-gcp-logger",
   "version": "1.1.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -33,6 +33,7 @@
     "typescript": "^4.3.5"
   },
   "author": "Pascal Zwikirsch",
+  "contributors": ["Uladzimir Aleshka"],
   "homepage": "https://github.com/mr-pascal/nestjs-gcp-logging",
   "bugs": {
     "url": "https://github.com/mr-pascal/nestjs-gcp-logging"

--- a/src/loggerParams.ts
+++ b/src/loggerParams.ts
@@ -4,5 +4,5 @@ export interface LoggerParams {
         If set to `true` the message of a 'error' log will be wrapped
         in a stack trace to be recognized by GCP's Error Reporting
     */
-    GCP_ERROR_REPORTING?: boolean;
+    gcpErrorReporting?: boolean;
 }

--- a/src/logging.module.ts
+++ b/src/logging.module.ts
@@ -1,6 +1,6 @@
-import {Global, Module} from '@nestjs/common';
-import {LoggerParams} from './loggerParams';
-import {LoggingService} from './logging.service';
+import { Global, Module } from '@nestjs/common';
+import { LoggerParams } from './loggerParams';
+import { LoggingService } from './logging.service';
 
 @Global()
 @Module({})
@@ -8,19 +8,13 @@ import {LoggingService} from './logging.service';
  * LoggingModule
  */
 export class LoggingModule {
-  public static register(
-      params: LoggerParams,
-  ) {
-    const loggingProvider = {
-      provide: LoggingService,
-      useFactory: async (): Promise<LoggingService> =>
-        LoggingService.load(params),
-    };
+  public static forRoot(params: LoggerParams) {
+    const provider = { provide: 'LoggingServiceParams', useValue: params };
 
     return {
       module: LoggingModule,
-      providers: [loggingProvider],
-      exports: [loggingProvider],
-    };
+      providers: [provider, LoggingService],
+      export: [LoggingService],
+    }
   }
 }

--- a/src/logging.service.spec.ts
+++ b/src/logging.service.spec.ts
@@ -1,6 +1,6 @@
-import {Test, TestingModule} from '@nestjs/testing';
-import {LoggingService} from './logging.service';
-import {Severity} from './severity';
+import { Test, TestingModule } from '@nestjs/testing';
+import { LoggingService } from './logging.service';
+import { Severity } from './severity';
 
 const logMessage = 'my message';
 const logSpy = jest.spyOn(console, 'log');
@@ -69,8 +69,8 @@ describe(`LoggingService with GCP_ERROR_REPORTING=true`, () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [LoggingService,
         {
-          provide: 'LoggingServiceParams', // this can be a symbol or a string
-          useValue: {GCP_ERROR_REPORTING: true},
+          provide: 'LoggingServiceParams',
+          useValue: { gcpErrorReporting: true },
         },
       ],
     }).compile();
@@ -86,7 +86,7 @@ describe(`LoggingService with GCP_ERROR_REPORTING=true`, () => {
     const severity = Severity.ERROR;
     it(`Should log with ${severity} severity and stack trace in message`, () => {
       service.error(logMessage);
-      // No need for checking the WHOLE stackstrace
+      // No need for checking the WHOLE stacktrace
       const expectedLog = expect.stringContaining(`{"severity":"${severity}","message":"Error: ${logMessage}\\n    at LoggingService.error`);
 
       expect(logSpy).toHaveBeenLastCalledWith(expectedLog);

--- a/src/logging.service.ts
+++ b/src/logging.service.ts
@@ -1,10 +1,10 @@
-import {ConsoleLogger, Inject, Injectable, LoggerService} from '@nestjs/common';
-import {LoggerParams} from './loggerParams';
-import {Severity} from './severity';
+import { ConsoleLogger, Inject, Injectable, LoggerService } from '@nestjs/common';
+import { LoggerParams } from './loggerParams';
+import { Severity } from './severity';
 
 @Injectable()
 /**
- * Service for writing logs in a GCP compatbile format
+ * Service for writing logs in a GCP compatible format
  */
 export class LoggingService extends ConsoleLogger implements LoggerService {
   private static params: LoggerParams;
@@ -15,20 +15,11 @@ export class LoggingService extends ConsoleLogger implements LoggerService {
    * @param {LoggerParams} params
    */
   constructor(
-      @Inject('LoggingServiceParams') params: LoggerParams = {
-        GCP_ERROR_REPORTING: false,
+      @Inject('LoggingServiceParams') private params: LoggerParams = {
+        gcpErrorReporting: false,
       },
   ) {
     super();
-    LoggingService.params = params;
-  }
-
-  /**
-   * Return a new instance of the LoggingService
-   * @param {LoggerParams} params
-   */
-  static async load(params: LoggerParams): Promise<LoggingService> {
-    return new LoggingService(params);
   }
 
   /**
@@ -44,15 +35,14 @@ export class LoggingService extends ConsoleLogger implements LoggerService {
    * @param {any} message
    */
   error(message: any) {
-    if (LoggingService.params.GCP_ERROR_REPORTING) {
-      // Wrapping the message in a Error stack makes the Error Reporter recognize it.
-      message = Error(
-        typeof message === "object" && !(message instanceof Error)
-          ? JSON.stringify(message)
-          : message,
-      ).stack;
+    if (this.params.gcpErrorReporting) {
+      const composedMessage = typeof message === 'object' && !(message instanceof Error)
+        ? JSON.stringify(message) : message;
+
+      message = new Error(composedMessage).stack;
     }
-    console.log(JSON.stringify({severity: Severity.ERROR, message: message}));
+
+    console.log(JSON.stringify({ severity: Severity.ERROR, message }));
   }
 
   /**

--- a/src/logging.service.ts
+++ b/src/logging.service.ts
@@ -7,7 +7,6 @@ import { Severity } from './severity';
  * Service for writing logs in a GCP compatible format
  */
 export class LoggingService extends ConsoleLogger implements LoggerService {
-  private static params: LoggerParams;
 
   /**
    * Constructor


### PR DESCRIPTION
### WHAT

Main changes (why I decided to create this PR)
1. `LoggingService.load()` was removed. Params passed via lazy module initialisation.
2. Using LoggingService switched from `new LoggingService()` to `app.get(LoggingService)`. It's needed to enable DI in it (and pass params).
3.  Now it's possible to mock this logger in tests (Sometimes it's useful to hide logs when you testing failure cases -> test logs will be cleaner)

```typescript
const testingModule = await Test.createTestingModule(...).override(LoggingService).useClass(LoggerMock).compile();
```

Not critical changes (I'm ok to revert that if it's critical for you)
1. change code styles (eslint/prettier)
2. switched from `GCP_ERROR_REPORTING` to `gcpErrorReporting` since it's field in params object. (not env var or constant)
3. switched from `.register` to `.forRoot` as more conventional - totally not critical

### VERSION

As soon as API was changed -> Major verison bump