### PR TITLE
Fix returning module metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pzwik/nestjs-gcp-logger",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pzwik/nestjs-gcp-logger",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "ISC",
       "dependencies": {
         "@nestjs/common": "^9.0.5",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   },
   "author": "Pascal Zwikirsch",
   "contributors": [
-    "Uladzimir Aleshka"
+    "Uladzimir Aleshka",
+    "Aliaksei Mahdzich"
   ],
   "homepage": "https://github.com/mr-pascal/nestjs-gcp-logging",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pzwik/nestjs-gcp-logger",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/src/logging.module.ts
+++ b/src/logging.module.ts
@@ -1,4 +1,4 @@
-import { Global, Module } from '@nestjs/common';
+import { DynamicModule, Global, Module } from '@nestjs/common';
 import { LoggerParams } from './loggerParams';
 import { LoggingService } from './logging.service';
 
@@ -8,13 +8,13 @@ import { LoggingService } from './logging.service';
  * LoggingModule
  */
 export class LoggingModule {
-  public static forRoot(params: LoggerParams) {
+  public static forRoot(params: LoggerParams): DynamicModule {
     const provider = { provide: 'LoggingServiceParams', useValue: params };
 
     return {
       module: LoggingModule,
       providers: [provider, LoggingService],
-      export: [LoggingService],
-    }
+      exports: [LoggingService],
+    };
   }
 }


### PR DESCRIPTION
Currently, we have a little typo when returning module metadata from the `forRoot` method. This PR fixes this typo and adds a return type to avoid similar issues. With this fix, it will be possible to use logger injection.